### PR TITLE
Fixing CORS support

### DIFF
--- a/README.md
+++ b/README.md
@@ -118,9 +118,15 @@ npm install --save cookie-parser body-parser
 #### <a name="usage-all"></a> Use with all routes
 
 
-To use the library with default options, simply require it, create a default
-middleware set, and pass it to your app:
+To use the library with default options, you will do the follwing:
 
+* Require the module
+* Create an instance of `spMiddlware`
+* Attach the default routes
+* Use the [`authenticate`](#authenticate) middleware on all your
+routes, via `app.use()`
+
+**Basic Usage Example:**
 ```javascript
 var cookieParser = require('cookie-parser');
 var bodyParser = require('body-parser');
@@ -133,13 +139,16 @@ var spConfig = {
   apiKeySecret: 'YOUR_STORMPATH_API_KEY_SECRET'
 }
 
-var spMiddleware = stormpathExpressSdk.createMiddleware(spConfig);
-
 var app = express();
 
 app.use(cookieParser());
 app.use(bodyParser.json());
-app.use(spMiddleware);
+
+var spMiddleware = stormpathExpressSdk.createMiddleware(spConfig);
+
+spMiddleware.attachDefaults(app);
+
+app.use(spMiddleware.authenticate);
 ```
 
 Doing this will enable the following functionality:
@@ -164,28 +173,17 @@ all POST requests will validated with an XSRF token as well.
 #### <a name="usage-some"></a> Use with some routes
 
 If you don't need to authenticate all routes, but still want to use token
-authentication, you can break it up like this:
+authentication, then don't use the statement `app.use(spMiddleware.authenticate)`.
+Instead, use the [`authenticate`](#authenticate) middleware on the
+routes that need authentication:
 
+**Specific Route Example:**
 ```javascript
-var spMiddleware = stormpathExpressSdk.createMiddleware(spConfig);
-
-var app = express();
-
-// Manually define the credential exchange endpoint
-
-app.post('/tokens',spMiddleware.authenticateForToken);
-
 // Enforce authentication on the API
 
 app.get('/api/*',spMiddleware.authenticate,function(req,res,next){
   // If we get here, the user has been authenticated
   // The account object is available at req.user
-});
-
-// Allow anyone to use the public site
-
-app.get('/public/*',function(){
-  res.send('This is the public site, authentication not required');
 });
 ```
 

--- a/test/authenticate.js
+++ b/test/authenticate.js
@@ -22,10 +22,11 @@ describe('authenticate middleware',function() {
         app = express();
         app.use(bodyParser.json());
         app.use(cookieParser());
-        app.use(require('../').createMiddleware({
+        var spMiddleware = require('../').createMiddleware({
           appHref: fixture.appHref
-        }));
-        app.post(protectedEndpoint,function(req,res){
+        });
+        spMiddleware.attachDefaults(app);
+        app.post(protectedEndpoint,spMiddleware.authenticate,function(req,res){
           res.json(req.body);
         });
         setTimeout(function(){
@@ -82,11 +83,12 @@ describe('authenticate middleware',function() {
         app = express();
         app.use(bodyParser.json());
         app.use(cookieParser());
-        app.use(require('../').createMiddleware({
+        var spMiddleware = require('../').createMiddleware({
           appHref: fixture.appHref,
           xsrf: false
-        }));
-        app.post(protectedEndpoint,function(req,res){
+        });
+        spMiddleware.attachDefaults(app);
+        app.post(protectedEndpoint,spMiddleware.authenticate,function(req,res){
           res.json(req.body);
         });
         setTimeout(function(){

--- a/test/authenticateBearerAuthorizationHeader.js
+++ b/test/authenticateBearerAuthorizationHeader.js
@@ -30,7 +30,8 @@ describe('authenticateBearerAuthorizationHeader',function() {
     });
     app = express();
     app.use(bodyParser.json());
-    app.use(spMiddleware);
+    spMiddleware.attachDefaults(app);
+    app.use(spMiddleware.authenticate);
     app.post(protectedEndpoint,function(req,res){
       res.json({ data: req.body, user: req.user });
     });
@@ -102,8 +103,8 @@ describe('authenticateBearerAuthorizationHeader',function() {
       });
       app = express();
       app.use(bodyParser.json());
-      app.use(spMiddleware);
-      app.post(protectedEndpoint,function(req,res){
+      spMiddleware.attachDefaults(app);
+      app.post(protectedEndpoint,spMiddleware.authenticate,function(req,res){
         res.json({ data: req.body, user: req.user });
       });
 

--- a/test/authenticateForToken.js
+++ b/test/authenticateForToken.js
@@ -33,7 +33,8 @@ describe('authenticateForToken',function() {
     });
     app = express();
     app.use(bodyParser.json());
-    app.use(spMiddleware);
+
+    spMiddleware.attachDefaults(app);
 
 
     pem.createCertificate({days:1, selfSigned:true}, function(err, keys){

--- a/test/authenticateUsernamePasswordForToken.js
+++ b/test/authenticateUsernamePasswordForToken.js
@@ -110,7 +110,7 @@ describe('authenticateUsernamePasswordForToken',function() {
           });
           app = express();
           app.use(bodyParser.json());
-          app.use(spMiddleware);
+          spMiddleware.attachDefaults(app);
 
           pem.createCertificate({days:1, selfSigned:true}, function(err, keys){
             server = https.createServer({key: keys.serviceKey, cert: keys.certificate}, app).listen(0);
@@ -199,7 +199,7 @@ describe('authenticateUsernamePasswordForToken',function() {
           });
           app = express();
           app.use(bodyParser.json());
-          app.use(spMiddleware);
+          spMiddleware.attachDefaults(app);
           var wait = setInterval(function(){
             /* wait for sp application */
             if(spMiddleware.getApplication()){
@@ -240,7 +240,7 @@ describe('authenticateUsernamePasswordForToken',function() {
           });
           app = express();
           app.use(bodyParser.json());
-          app.use(spMiddleware);
+          spMiddleware.attachDefaults(app);
 
           var wait = setInterval(function(){
             /* wait for sp application */
@@ -287,7 +287,7 @@ describe('authenticateUsernamePasswordForToken',function() {
             }
           });
           app.use(bodyParser.json());
-          app.use(spMiddleware);
+          spMiddleware.attachDefaults(app);
 
           pem.createCertificate({days:1, selfSigned:true}, function(err, keys){
             server = https.createServer({key: keys.serviceKey, cert: keys.certificate}, app).listen(0);
@@ -353,7 +353,7 @@ describe('authenticateUsernamePasswordForToken',function() {
           });
           app = express();
           app.use(bodyParser.json());
-          app.use(spMiddleware);
+          spMiddleware.attachDefaults(app);
           var wait = setInterval(function(){
             /* wait for sp application */
             if(spMiddleware.getApplication()){
@@ -401,7 +401,7 @@ describe('authenticateUsernamePasswordForToken',function() {
           });
           app = express();
           app.use(bodyParser.json());
-          app.use(spMiddleware);
+          spMiddleware.attachDefaults(app);
           var wait = setInterval(function(){
             /* wait for sp application */
             if(spMiddleware.getApplication()){

--- a/test/cookie-options.js
+++ b/test/cookie-options.js
@@ -22,7 +22,7 @@ describe('accessTokenCookieName option',function() {
         });
         app = express();
         app.use(bodyParser.json());
-        app.use(spMiddleware);
+        spMiddleware.attachDefaults(app);
 
         var wait = setInterval(function(){
           /* wait for sp application */
@@ -51,7 +51,7 @@ describe('accessTokenCookieName option',function() {
         });
         app = express();
         app.use(bodyParser.json());
-        app.use(spMiddleware);
+        spMiddleware.attachDefaults(app);
 
         var wait = setInterval(function(){
           /* wait for sp application */

--- a/test/custom-error-handlers.js
+++ b/test/custom-error-handlers.js
@@ -17,8 +17,8 @@ describe('endOnError option',function() {
         });
         app = express();
         app.use(bodyParser.json());
-        app.use(spMiddleware);
-        app.get(protectedUri,function(req,res){
+        spMiddleware.attachDefaults(app);
+        app.get(protectedUri,spMiddleware.authenticate,function(req,res){
           res.json({authenticationError:req.authenticationError.userMessage});
         });
         var wait = setInterval(function(){
@@ -46,7 +46,7 @@ describe('endOnError option',function() {
         });
         app = express();
         app.use(bodyParser.json());
-        app.use(spMiddleware);
+        app.use(spMiddleware.authenticate);
         var wait = setInterval(function(){
           /* wait for sp application */
           if(spMiddleware.getApplication()){

--- a/test/index.js
+++ b/test/index.js
@@ -52,9 +52,9 @@ describe('the user agent of this library',function(){
     }).listen(0,function(){
       appHref = 'http://0.0.0.0:'+mockApiServer.address().port+'/an-application';
       app = express();
-      app.use(stormpathSdkExpress.createMiddleware({
+      stormpathSdkExpress.createMiddleware({
         appHref: appHref
-      }));
+      });
     });
 
 

--- a/test/write-tokens-option.js
+++ b/test/write-tokens-option.js
@@ -55,7 +55,7 @@ describe('writeTokens option',function() {
         });
         app = express();
         app.use(bodyParser.json());
-        app.use(spMiddleware);
+        spMiddleware.attachDefaults(app);
 
         var wait = setInterval(function(){
           /* wait for sp application */


### PR DESCRIPTION
Cors headers were not being added if using the `attachDefaults()` method for registering the middleware, this branch fixes that problem.

`index.js` has been refactored for readability

`attachDefaults()` is now the documented method for basic usage.  `app.use(spMiddlware)` still works, but is removed from documentation for now (as we instruct you to use `attachDefaults()` on the Angular Guide)
