### PR TITLE
Adding social login to SDK.

### DIFF
--- a/README.md
+++ b/README.md
@@ -81,6 +81,7 @@ application, which is part of our [Stormpath AngularJS SDK](https://github.com/s
  * [authenticateCookie](#authenticateCookie)
  * [authenticateForToken](#authenticateForToken)
  * [authenticateUsernamePasswordForToken](#authenticateUsernamePasswordForToken)
+ * [authenticateSocialForToken](#authenticateSocialForToken)
  * [groupsRequired](#groupsRequired)
  * [logout](#logout)
  * [writeToken](#writeToken)
@@ -158,11 +159,12 @@ Doing this will enable the following functionality:
 [`authenticate`](#authenticate) middleware, which will assert that the user has
 an existing access token.  If this is not true, an error response will be sent.
 
-* The endpoint `/oauth/token` will accept Client Password or Client Credential grant
-requests and respond with an access token if authentication is successful.
-Depending on the grant type (`password` or `client_credentials`) it delegates to
+* The endpoint `/oauth/token` will accept Client Password, Client Credential, or
+ Social Login grant requests and respond with an access token if authentication is successful.
+Depending on the grant type (`password`, `client_credentials`, or 'social') it delegates to
 [`authenticateUsernamePasswordForToken`](#authenticateUsernamePasswordForToken)
-or [`authenticateApiKeyForToken`](#authenticateApiKeyForToken).
+, [`authenticateApiKeyForToken`](#authenticateApiKeyForToken) or
+[`authenticateSocialForToken`](#authenticateSocialForToken).
 
 * The `/logout` endpoint will be provided for ending cookie-based sessions.
 
@@ -220,7 +222,7 @@ var spConfig = {
 }
 ```
 
-Used by [`authenticateUsernamePasswordForToken`](#authenticateUsernamePasswordForToken), [`authenticateApiKeyForToken`](#authenticateApiKeyForToken)
+Used by [`authenticateUsernamePasswordForToken`](#authenticateUsernamePasswordForToken), [`authenticateApiKeyForToken`](#authenticateApiKeyForToken), [`authenticateSocialForToken`](#authenticateSocialForToken)
 
 
 
@@ -250,7 +252,7 @@ var spConfig = {
 }
 ```
 
-Used by [`authenticateUsernamePasswordForToken`](#authenticateUsernamePasswordForToken), [`authenticateCookie`](#authenticateCookie)
+Used by [`authenticateUsernamePasswordForToken`](#authenticateUsernamePasswordForToken), [`authenticateCookie`](#authenticateCookie), [`authenticateSocialForToken`](#authenticateSocialForToken)
 
 
 
@@ -275,7 +277,7 @@ var spConfig = {
 
 When enabled, the response body will be a [`TokenResponse`](#TokenResponse)
 
-Used by [`authenticateUsernamePasswordForToken`](#authenticateUsernamePasswordForToken)
+Used by [`authenticateUsernamePasswordForToken`](#authenticateUsernamePasswordForToken), [`authenticateSocialForToken`](#authenticateSocialForToken)
 
 
 
@@ -683,14 +685,43 @@ var app = express();
 app.post('/login',spMiddleware.authenticateUsernamePasswordForToken);
 ````
 
+### <a name="authenticateSocialForToken"></a> authenticateSocialForToken
+
+Expects a JSON POST body, which has a `providerId` and `accessToken` field, and a
+grant type request of `social`.
+
+**Example: posting providerId and accessToken to the token endpoint**
+```
+POST /oauth/tokens?grant_type=social
+
+{
+  "providerId": "facebook",
+  "accessToken": "aTokenReceivedFromFacebookLogin"
+}
+```
+
+If the supplied accessToken is valid for the provider, this function will respond
+with an access token cookie or access token response, depending on the configuration
+set by [`writeAccessTokenResponse`](#access-token-response) and
+[`writeAccessTokenToCookie`](#access-token-cookie)
+
+**Example: accept only social for token exchange**
+````javascript
+var spMiddleware = stormpathExpressSdk.createMiddleware({/* options */})
+
+var app = express();
+
+app.post('/login',spMiddleware.authenticateSocialForToken);
+````
 
 
 
 #### <a name="authenticateForToken"></a> authenticateForToken
 
 This is a convenience middleware that will inspect the request
-and delegate to [`authenticateApiKeyForToken`](#authenticateApiKeyForToken) or
+and delegate to [`authenticateApiKeyForToken`](#authenticateApiKeyForToken),
 [`authenticateUsernamePasswordForToken`](#authenticateUsernamePasswordForToken)
+or [`authenticateSocialForToken`](#authenticateSocialForToken)
 
 **Example: manually defining the token endpoint**
 ````javascript

--- a/lib/middleware/authenticateForToken.js
+++ b/lib/middleware/authenticateForToken.js
@@ -8,6 +8,8 @@ function authenticateForToken(req,res, next){
 
   if(urlParams.grant_type && urlParams.grant_type==='password'){
     context.authenticateUsernamePasswordForToken(req,res,next);
+  }else if(urlParams.grant_type && urlParams.grant_type==='social'){
+    context.authenticateSocialForToken(req,res,next);
   }else if(urlParams.grant_type && urlParams.grant_type==='client_credentials'){
     context.authenticateApiKeyForToken(req,res,next);
   }else{

--- a/lib/middleware/authenticateSocialForToken.js
+++ b/lib/middleware/authenticateSocialForToken.js
@@ -1,0 +1,74 @@
+var url = require('url');
+
+function authenticateSocialForToken(req,res, next){
+  var context = this;
+  var properties = context.properties;
+  var spApplication = context.getApplication();
+
+  var tokenWriter = context.tokenWriter;
+  var scopeFactory = context.scopeFactory;
+
+  var urlParams = url.parse(req.url,true).query;
+  var requestedScope = (req.body && req.body.scope) || urlParams.scope || '';
+  if(!spApplication){
+    return context.handleApplicationError(properties.errors.library.SP_APP_UNINITIALIZED,res);
+  }
+  else if(req.body && req.body.providerId && req.body.accessToken) {
+    spApplication.getAccount({
+      providerData: {
+        providerId: req.body.providerId,
+        accessToken: req.body.accessToken
+      }
+    }, function (err, accountResult) {
+      if (err) {
+        context.handleAuthenticationError(err, req, res, next);
+      } else {
+        // writeTokens expects an authenticationResult, so we'll act like one
+        req.authenticationResult = accountResult;
+        req.authenticationResult.getAccessTokenResponse = function getAccessTokenResponse(jwt) {
+          jwt = jwt || this.getJwt();
+          var resp = {
+            'access_token': jwt.compact(),
+            'token_type': 'Bearer',
+            'expires_in': jwt.ttl
+          };
+          if (jwt.body.scope) {
+            resp.scope = jwt.body.scope;
+          }
+          return resp;
+        };
+        req.user = accountResult.account;
+        req.jwt = context.jwtLib.Jwt({
+          iss: context.spConfig.appHref,
+          sub: accountResult.account.href,
+          jti: context.getUuid()
+        }).signWith('HS256',context.spConfig.apiKeySecret).setTtl(3600);
+
+        if (context.spConfig.writeTokens && scopeFactory) {
+          scopeFactory(req, res, accountResult, accountResult.account, requestedScope,
+              function (err, scope) {
+                if (err) {
+                  context.handleAuthenticationError(err, req, res, next);
+                } else if (scope) {
+                  req.jwt.body.scope = scope;
+                  tokenWriter(req, res);
+                } else {
+                  tokenWriter(req, res);
+                }
+              });
+        } else if (context.spConfig.writeTokens) {
+          tokenWriter(req, res);
+        } else {
+          next();
+        }
+      }
+    });
+  }else{
+    context.handleAuthenticationError({
+      status: 400,
+      userMessage:properties.errors.authentication.BAD_ACCESS_TOKEN_BODY
+    },req,res,next);
+  }
+}
+
+module.exports = authenticateSocialForToken;

--- a/properties.json
+++ b/properties.json
@@ -10,6 +10,7 @@
     "authentication":{
       "UNAUTHENTICATED": "Authentication required",
       "BAD_PASSWORD_BODY": "Missing username or password in post body",
+      "BAD_ACCESS_TOKEN_BODY": "Missing providerId or accessToken in post body",
       "UNKNOWN": "An error has occurred during authentication",
       "UNSUPPORTED_GRANT_TYPE": "Unsupported grant type"
     },

--- a/test/authenticateSocialForToken.js
+++ b/test/authenticateSocialForToken.js
@@ -10,17 +10,17 @@ var loginSuccessFixture = require('./fixtures/loginSuccess');
 var properties = require('../properties.json');
 var stormpathSdkExpress = require('../');
 
-describe('authenticateUsernamePasswordForToken',function() {
+describe('authenticateSocialForToken',function() {
 
-  var tokenEndpoint = properties.configuration.DEFAULT_TOKEN_ENDPOINT + '?grant_type=password';
+  var tokenEndpoint = properties.configuration.DEFAULT_TOKEN_ENDPOINT + '?grant_type=social';
 
   describe('if the sp app is not yet initialized',function(){
     var app;
 
     /*
-      Mock context.  Manually proviede an undfined value
-      for the application
-    */
+     Mock context.  Manually proviede an undfined value
+     for the application
+     */
 
     var spConfig = {
       spClient: {
@@ -35,17 +35,17 @@ describe('authenticateUsernamePasswordForToken',function() {
 
     before(function(){
       app = express();
-      app.use(stormpathSdkExpress.AuthenticateUsernamePasswordForToken(spConfig));
+      app.use(stormpathSdkExpress.AuthenticateSocialForToken(spConfig));
     });
     it('should error',function(done){
       request(app)
-        .post('/')
-        .expect(500,{errorMessage:properties.errors.library.SP_APP_UNINITIALIZED},done);
+          .post('/')
+          .expect(500,{errorMessage:properties.errors.library.SP_APP_UNINITIALIZED},done);
     });
   });
 
 
-  describe('if the request does not contain login & password',function(){
+  describe('if the request does not contain providerId & accessToken',function(){
 
     var app;
 
@@ -64,27 +64,27 @@ describe('authenticateUsernamePasswordForToken',function() {
 
     before(function(){
       app = express();
-      app.use(stormpathSdkExpress.AuthenticateUsernamePasswordForToken(spConfig));
+      app.use(stormpathSdkExpress.AuthenticateSocialForToken(spConfig));
     });
 
     it('should error',function(done){
 
       request(app)
-        .post('/')
-        .expect(400,{errorMessage:properties.errors.authentication.BAD_PASSWORD_BODY},done);
+          .post('/')
+          .expect(400,{errorMessage:properties.errors.authentication.BAD_ACCESS_TOKEN_BODY},done);
 
     });
 
   });
 
 
-  describe('with a request that contains a valid password-based login',function(){
+  describe('with a request that contains a valid accessToken-based login',function(){
     var jwtExpr = /[^\.]+\.[^\.]+\.[^;]+/;
     var httpOnlyCookieExpr = /access_token=[^\.]+\.[^\.]+\.[^;]+; Expires=[^;]+; HttpOnly;/;
     var httpsOnlyCookieExpr = /access_token=[^\.]+\.[^\.]+\.[^;]+; Expires=[^;]+; Secure; HttpOnly;/;
     var xsrfTokenCookieExpr = /XSRF-TOKEN=[0-9A-Za-z\-]+; Expires=[^;]+;/;
 
-    var mockLoginPost = {username:'abc',password:'123'};
+    var mockLoginPost = {providerId:'facebook',accessToken:'123'};
     var parser = nJwt.Parser().setSigningKey('123');
     var customRequestedScope = 'quiero';
     var customScope = 'my-custom scope';
@@ -131,60 +131,60 @@ describe('authenticateUsernamePasswordForToken',function() {
 
       it('should write an access token in a Secure, HttpOnly cookie',function(done){
         request(server)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .expect('set-cookie', httpsOnlyCookieExpr)
-          .expect(201,'',done);
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .expect('set-cookie', httpsOnlyCookieExpr)
+            .expect(201,'',done);
       });
 
       describe('and scope is requested',function(){
         describe('via URL params',function(){
           it('should preserve scope from the scope factory in the access token',function(done){
             request(server)
-              .post(tokenEndpoint+'&scope='+customRequestedScope)
-              .send(mockLoginPost)
-              .expect('set-cookie', httpsOnlyCookieExpr)
-              .expect(201,'')
-              .end(function(err,res) {
-                var access_token = res.headers['set-cookie'][1].match(/access_token=([^;]+)/)[1];
-                parser.parseClaimsJws(access_token,function(err,jwt) {
-                  assert.equal(jwt.body.scope,requestedScopeReflection(customScope,customRequestedScope));
-                  done();
+                .post(tokenEndpoint+'&scope='+customRequestedScope)
+                .send(mockLoginPost)
+                .expect('set-cookie', httpsOnlyCookieExpr)
+                .expect(201,'')
+                .end(function(err,res) {
+                  var access_token = res.headers['set-cookie'][1].match(/access_token=([^;]+)/)[1];
+                  parser.parseClaimsJws(access_token,function(err,jwt) {
+                    assert.equal(jwt.body.scope,requestedScopeReflection(customScope,customRequestedScope));
+                    done();
+                  });
                 });
-              });
           });
         });
 
         describe('via post body',function(){
           it('should preserve scope from the scope factory in the access token',function(done){
             request(server)
-              .post(tokenEndpoint)
-              .send({username:mockLoginPost.username,password:mockLoginPost.password,scope:customRequestedScope})
-              .expect('set-cookie', httpsOnlyCookieExpr)
-              .expect(201,'')
-              .end(function(err,res) {
-                var access_token = res.headers['set-cookie'][1].match(/access_token=([^;]+)/)[1];
-                parser.parseClaimsJws(access_token,function(err,jwt) {
-                  assert.equal(jwt.body.scope,requestedScopeReflection(customScope,customRequestedScope));
-                  done();
+                .post(tokenEndpoint)
+                .send({providerId:mockLoginPost.providerId,accessToken:mockLoginPost.accessToken,scope:customRequestedScope})
+                .expect('set-cookie', httpsOnlyCookieExpr)
+                .expect(201,'')
+                .end(function(err,res) {
+                  var access_token = res.headers['set-cookie'][1].match(/access_token=([^;]+)/)[1];
+                  parser.parseClaimsJws(access_token,function(err,jwt) {
+                    assert.equal(jwt.body.scope,requestedScopeReflection(customScope,customRequestedScope));
+                    done();
+                  });
                 });
-              });
           });
         });
       });
       it('should write an xsrf cookie',function(done){
         request(app)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .expect('set-cookie', xsrfTokenCookieExpr)
-          .expect(201,'',done);
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .expect('set-cookie', xsrfTokenCookieExpr)
+            .expect(201,'',done);
       });
 
       it('should not write a response body',function(done){
         request(app)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .expect(201,'',done);
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .expect(201,'',done);
       });
     });
 
@@ -213,17 +213,17 @@ describe('authenticateUsernamePasswordForToken',function() {
       it('should write an access token to an http-only cookie',function(done){
 
         request(app)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .expect('set-cookie', httpOnlyCookieExpr, done);
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .expect('set-cookie', httpOnlyCookieExpr, done);
 
       });
       it('should write an empty body with 201 response',function(done){
 
         request(app)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .expect(201,'',done);
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .expect(201,'',done);
 
       });
     });
@@ -254,18 +254,18 @@ describe('authenticateUsernamePasswordForToken',function() {
 
       it('should write an access token in a Secure, HttpOnly cookie',function(done){
         request(app)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .expect('set-cookie', httpsOnlyCookieExpr)
-          .expect(201,'',done);
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .expect('set-cookie', httpsOnlyCookieExpr)
+            .expect(201,'',done);
       });
 
       it('should write an empty body with 201 response',function(done){
 
         request(app)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .expect(201,'',done);
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .expect(201,'',done);
 
       });
     });
@@ -305,38 +305,38 @@ describe('authenticateUsernamePasswordForToken',function() {
 
       it('should write an access token in a Secure, HttpOnly cookie',function(done){
         request(server)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .expect('set-cookie', httpsOnlyCookieExpr, done);
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .expect('set-cookie', httpsOnlyCookieExpr, done);
       });
 
       it('should write access tokens to the response bodies',function(done){
 
         request(server)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .end(function(err,res){
-            assert(res.body.access_token.match(jwtExpr));
-            assert(res.body.token_type==='Bearer');
-            assert(res.body.expires_in===3600);
-            done();
-          });
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .end(function(err,res){
+              assert(res.body.access_token.match(jwtExpr));
+              assert(res.body.token_type==='Bearer');
+              assert(res.body.expires_in===3600);
+              done();
+            });
 
       });
 
       it('should preserve scope from the scope factory in the response body and access token',function(done){
         request(server)
-          .post(tokenEndpoint+'&scope='+customRequestedScope)
-          .send(mockLoginPost)
-          .end(function(err,res) {
-            var access_token = res.headers['set-cookie'][1].match(/access_token=([^;]+)/)[1];
+            .post(tokenEndpoint+'&scope='+customRequestedScope)
+            .send(mockLoginPost)
+            .end(function(err,res) {
+              var access_token = res.headers['set-cookie'][1].match(/access_token=([^;]+)/)[1];
 
-            assert.equal(res.body.scope,customScope);
-            parser.parseClaimsJws(access_token,function(err,jwt) {
-              assert.equal(jwt.body.scope,customScope);
-              done();
+              assert.equal(res.body.scope,customScope);
+              parser.parseClaimsJws(access_token,function(err,jwt) {
+                assert.equal(jwt.body.scope,customScope);
+                done();
+              });
             });
-          });
       });
     });
 
@@ -366,25 +366,25 @@ describe('authenticateUsernamePasswordForToken',function() {
 
       it('should not write an access token cookie',function(done){
         request(app)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .end(function(err,res){
-            assert(httpsOnlyCookieExpr.test(res.headers['set-cookie'].join(','))===false);
-            done();
-          });
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .end(function(err,res){
+              assert(httpsOnlyCookieExpr.test(res.headers['set-cookie'].join(','))===false);
+              done();
+            });
       });
 
       it('should write an access token tresponse body',function(done){
 
         request(app)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .end(function(err,res){
-            assert(res.body.access_token.match(jwtExpr));
-            assert(res.body.token_type==='Bearer');
-            assert(res.body.expires_in===3600);
-            done();
-          });
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .end(function(err,res){
+              assert(res.body.access_token.match(jwtExpr));
+              assert(res.body.token_type==='Bearer');
+              assert(res.body.expires_in===3600);
+              done();
+            });
 
       });
     });
@@ -414,20 +414,20 @@ describe('authenticateUsernamePasswordForToken',function() {
 
       it('should not write an access token cookie',function(done){
         request(app)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .end(function(err,res){
-            assert(httpOnlyCookieExpr.test(res.headers['set-cookie'].join(','))===false);
-            assert(httpsOnlyCookieExpr.test(res.headers['set-cookie'].join(','))===false);
-            done();
-          });
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .end(function(err,res){
+              assert(httpOnlyCookieExpr.test(res.headers['set-cookie'].join(','))===false);
+              assert(httpsOnlyCookieExpr.test(res.headers['set-cookie'].join(','))===false);
+              done();
+            });
       });
 
       it('should write an empty body with 201 response',function(done){
         request(app)
-          .post(tokenEndpoint)
-          .send(mockLoginPost)
-          .expect(201,'',done);
+            .post(tokenEndpoint)
+            .send(mockLoginPost)
+            .expect(201,'',done);
       });
     });
 

--- a/test/fixtures/loginSuccess.js
+++ b/test/fixtures/loginSuccess.js
@@ -26,7 +26,6 @@ function loginSuccessFixture2(done){
 
 
 function loginSuccessFixture(base,expressApp) {
-
   var appUri = '/v1/application/'+uuid();
   var accountUri = '/v1/accounts/'+uuid();
 
@@ -34,14 +33,18 @@ function loginSuccessFixture(base,expressApp) {
   var loginAttemptsUri = appUri + '/loginAttempts';
   var loginAttemptsHref = base + loginAttemptsUri;
   var accountHref = base+accountUri;
+  var accountsUri = '/v1/applications/'+uuid() + '/accounts';
+  var accountsHref = base+accountsUri;
 
   expressApp.get(appUri,function(req,res){
-    res.json({href:appHref,loginAttempts:{href:loginAttemptsHref}});
+    res.json({href:appHref,
+      loginAttempts:{href:loginAttemptsHref},
+      accounts:{href:accountsHref}});
   });
 
-  expressApp.get(accountUri,function(req,res){
+  expressApp.post(accountsUri,function(req,res){
     res.json({
-      href:accountHref,
+      href:accountsHref,
       status: "ENABLED"
     });
   });
@@ -53,6 +56,7 @@ function loginSuccessFixture(base,expressApp) {
       }
     });
   });
+
   return {
     appHref: appHref,
     accountHref: accountHref


### PR DESCRIPTION
Recognizes authentication with grant_type of 'social' and calls getAccount with provider data.  Upon successful retrieval of the account JWT is created and returned.

Tests based heavily on UsernameAndPassword tests, modified to test new grant_type and authenticate method.

Fixes issue #10.
