### PR TITLE
A group required functionality needed for sdk to allow user to have belong to at least one user group.

### DIFF
--- a/lib/middleware/aGroupRequired.js
+++ b/lib/middleware/aGroupRequired.js
@@ -1,0 +1,36 @@
+'use strict';
+
+var _ = require('underscore');
+
+function assertAGroup(context,list,req,res,next) {
+
+  req.user.getGroups(function(err,groupsCollection) {
+    if(err){
+      context.handleSdkError(err,res);
+    }else{
+      if(_.intersection(list,_.pluck(groupsCollection.items,'name')).length > 0){
+        next();
+      }else{
+        context.handleAuthorizationError({},req,res,next);
+      }
+    }
+  });
+}
+
+function aGroupRequired(groupFilter){
+  var context = this;
+  var list = Array.isArray(groupFilter) ? groupFilter : ( typeof groupFilter === 'string' ? [groupFilter] : []);
+  return function (req,res,next) {
+    if(req.user){
+      assertAGroup(context,list,req,res,next);
+    }else{
+      context.authenticate(req,res,function(req,res) {
+        assertAGroup(context,list,req,res,next);
+      }.bind(context,req,res));
+    }
+
+  };
+
+}
+
+module.exports = aGroupRequired;


### PR DESCRIPTION
Could you please implement this functionality that allows users to belong to at least one of the authorized groups?

This is such an awesome feature, but I can't see it in this SDK repo.
Although it is available in the express-stormpath repo, this great feature is not available in the stormpath-sdk-express repo.

Basically to mirror:
app.get('/any_user', stormpath.groupsRequired(['free users', 'paid users', 'admins'], false), function (req, res) {
  res.send('If you can see this page, you must be in at least one of the specified groups!');
});

If this is already available in the current storm path, please let me know.

Thanks a lot.
