### PR TITLE
Update uuid to version 3.0.0

### DIFF
--- a/lib/MiddlewareContext.js
+++ b/lib/MiddlewareContext.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var nJwt = require('njwt');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 var stormpath = require('stormpath');
 
 var pkg = require('../package.json');

--- a/package.json
+++ b/package.json
@@ -40,11 +40,11 @@
     "test-cov": "istanbul cover node_modules/mocha/bin/_mocha -- --timeout=5000 --reporter dot --check-leaks test/"
   },
   "dependencies": {
-    "node-uuid": "^1.4.2",
-    "stormpath": "^0.9.0",
-    "njwt": "0.0.1",
     "async": "^0.9.0",
-    "underscore": "^1.8.2"
+    "njwt": "0.0.1",
+    "stormpath": "^0.9.0",
+    "underscore": "^1.8.2",
+    "uuid": "^3.0.0"
   },
   "devDependencies": {
     "mocha": "^2.1.0",

--- a/test/authenticate.js
+++ b/test/authenticate.js
@@ -2,7 +2,7 @@ var bodyParser = require('body-parser');
 var cookieParser = require('cookie-parser');
 var express = require('express');
 var request = require('supertest');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 var loginSuccessFixture = require('./fixtures/loginSuccess');
 var mockLoginPost = {username:'abc',password:'123'};

--- a/test/fixtures/loginSuccess.js
+++ b/test/fixtures/loginSuccess.js
@@ -8,7 +8,7 @@
 var bodyParser = require('body-parser');
 var express = require('express');
 var http = require('http');
-var uuid = require('node-uuid');
+var uuid = require('uuid');
 
 function loginSuccessFixture2(done){
   var app = express();


### PR DESCRIPTION
## Version 3.0.0 of [uuid](https://github.com/kelektiv/node-uuid) just got published.

Hi there,

This week a new version of the [uuid](https://github.com/kelektiv/node-uuid) module got released. The old module which was available by the name [node-uuid](https://www.npmjs.com/package/node-uuid) got deprecated and will show error message upon every install of the module.

To get rid of those install errors I've created this **automated pull request**. I've run some checks against your code base to test whether you're using one of the [deprecated apis](https://github.com/kelektiv/node-uuid/commit/5ae7287fc935eb55ef39133e4be17ef623ca000e), but this isn't the case.


Please test the changes against your code. I didn't run any tests and therefore can't guarantee that it isn't breaking. You can also just close this pr if you don't want to update your module.

In case there's already another pr open to upgrade uuid, I'm sorry for the effort I'm causing.